### PR TITLE
Auto-mount a USB drive over /mnt/src partition

### DIFF
--- a/overlay/etc/systemd/system/usbdrive@.service
+++ b/overlay/etc/systemd/system/usbdrive@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Replace /mnt/src with USB drive"
+
+[Service]
+Type=forking
+GuessMainPID=no
+RemainAfterExit=yes
+
+ExecStartPre=-/usr/bin/systemctl stop v2x-v2xgateway
+ExecStartPre=/usr/bin/systemctl stop mnt-src.mount
+ExecStart=/usr/bin/mount /dev/%I /mnt/src
+ExecStartPost=-/bin/sh -c "/usr/bin/systemctl is-enabled v2x-v2xgateway && /usr/bin/systemctl start v2x-v2xgateway"
+
+ExecStop=-/usr/bin/systemctl stop v2x-v2xgateway
+ExecStop=/usr/bin/systemctl stop mnt-src.mount
+ExecStopPost=/usr/bin/mount /dev/mmcblk0p3 /mnt/src
+ExecStopPost=-/bin/sh -c "/usr/bin/systemctl is-enabled v2x-v2xgateway && /usr/bin/systemctl start v2x-v2xgateway"

--- a/overlay/etc/udev/rules.d/usbdrive.rules
+++ b/overlay/etc/udev/rules.d/usbdrive.rules
@@ -1,0 +1,2 @@
+KERNEL=="sd?1", SUBSYSTEMS=="block", ACTION=="add", RUN+="/usr/bin/systemctl --no-block start usbdrive@%k.service"
+KERNEL=="sd?1", SUBSYSTEMS=="block", ACTION=="remove", RUN+="/usr/bin/systemctl --no-block stop usbdrive@%k.service"


### PR DESCRIPTION
This will also stop v2x-v2xgateway while re-mounting partitions!

I'm not quite happy with how stopping "v2x-v2xgateway" is handled before the unmount commands. But we need to stop it because otherwise unmount would fail because the device is busy (and it's nicer anyway).